### PR TITLE
Drop node-forge dependency

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -6,7 +6,6 @@ const punycode = require('punycode/');
 const libmime = require('libmime');
 const dns = require('dns').promises;
 const crypto = require('crypto');
-const pki = require('node-forge').pki;
 const https = require('https');
 const packageData = require('../package');
 const parseDkimHeaders = require('./parse-dkim-headers');
@@ -262,8 +261,9 @@ const getPublicKey = async (type, name, minBitLength, resolver) => {
             throw err;
         }
 
-        publicKey = Buffer.from(`-----BEGIN PUBLIC KEY-----\n${publicKey}\n-----END PUBLIC KEY-----`);
-        let keyType = crypto.createPublicKey({ key: publicKey, format: 'pem' }).asymmetricKeyType;
+        publicKeyPem = Buffer.from(`-----BEGIN PUBLIC KEY-----\n${publicKey}\n-----END PUBLIC KEY-----`);
+        publicKey = crypto.createPublicKey({ key: publicKeyPem, format: 'pem' });
+        let keyType = publicKey.asymmetricKeyType;
 
         if (!['rsa', 'ed25519'].includes(keyType) || (entry?.parsed?.k && entry?.parsed?.k?.value?.toLowerCase() !== keyType)) {
             let err = new Error('Unknown key type');
@@ -274,8 +274,7 @@ const getPublicKey = async (type, name, minBitLength, resolver) => {
 
         if (keyType === 'rsa') {
             // check key length
-            const pubKeyData = pki.publicKeyFromPem(publicKey.toString());
-            if (pubKeyData.n.bitLength() < 1024) {
+            if (publicKey.modulusLength < 1024) {
                 let err = new Error('Key too short');
                 err.code = 'ESHORTKEY';
                 err.rr = rr;
@@ -283,7 +282,7 @@ const getPublicKey = async (type, name, minBitLength, resolver) => {
             }
         }
 
-        return { publicKey, rr };
+        return { publicKeyPem, rr };
     }
 
     let err = new Error('Missing key value');

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -282,7 +282,7 @@ const getPublicKey = async (type, name, minBitLength, resolver) => {
             }
         }
 
-        return { publicKeyPem, rr };
+        return { publicKey: publicKeyPem, rr };
     }
 
     let err = new Error('Missing key value');

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
         "ipaddr.js": "2.0.1",
         "joi": "17.4.2",
         "libmime": "5.0.0",
-        "node-forge": "0.10.0",
         "nodemailer": "6.7.0",
         "psl": "1.8.0",
         "punycode": "2.1.1",


### PR DESCRIPTION
Used `node-forge` version has multiple security issues:

```
$ npm audit --production
# npm audit report
node-forge  <1.0.0
Prototype Pollution in node-forge debug API. - https://github.com/advisories/GHSA-5rrq-pxf6-6jx5
No fix available
node_modules/mailauth/node_modules/node-forge
  mailauth  *
  Depends on vulnerable versions of node-forge
  node_modules/mailauth
2 low severity vulnerabilities
Some issues need review, and may require choosing
a different dependency.
```

This pull requests removes `node-forge` dependency and replaces the functionality with node.js `crypto`.