### PR TITLE
Added support for SPF PTR

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Where
         -   **selector** (_string_) ARC key selector
         -   **privateKey** (_string_ or _buffer_) Private key for signing. Either an RSA or an Ed25519 key
     -   **resolver** (_async function_) is an optional async function for DNS requests. Defaults to [dns.promises.resolve](https://nodejs.org/api/dns.html#dns_dnspromises_resolve_hostname_rrtype)
-    -   **maxResolveCount** (_number_ defaults to _50_) is the DNS lookup limit for SPF. [RFC7208](https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4) requires this limit to be 10. Mailauth is less strict and defaults to 50.
+    -   **maxResolveCount** (_number_ defaults to _10_) is the DNS lookup limit for SPF. [RFC7208](https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4) requires this limit to be 10.
+    -   **maxVoidCount** (_number_ defaults to _2_) is the DNS lookup limit for SPF that produce an empty result. [RFC7208](https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4) requires this limit to be 2.
 
 **Example**
 
@@ -403,7 +404,6 @@ The function returns a boolean. If it is `true`, then MX hostname is allowed to 
 
 [OpenSPF test suite](http://www.openspf.org/Test_Suite) ([archive.org mirror](https://web.archive.org/web/20190130131432/http://www.openspf.org/Test_Suite)) with the following differences:
 
--   No PTR support in `mailauth`. All PTR related tests are ignored
 -   Less strict whitespace checks (`mailauth` accepts multiple spaces between tags etc.)
 -   Some macro tests are skipped (macro expansion is supported _in most parts_)
 -   Some tests where the invalid component is listed after a matching part (mailauth processes from left to right and returns on the first match found)

--- a/bin/mailauth.js
+++ b/bin/mailauth.js
@@ -52,7 +52,13 @@ const argv = yargs(hideBin(process.argv))
                     alias: 'x',
                     type: 'number',
                     description: 'Maximum allowed DNS lookups',
-                    default: 50
+                    default: 10
+                })
+                .option('max-void-lookups', {
+                    alias: 'z',
+                    type: 'number',
+                    description: 'Maximum allowed empty DNS lookups',
+                    default: 2
                 });
             yargs.positional('email', {
                 describe: 'Path to the email message file in EML format. If not specified then content is read from stdin'
@@ -275,7 +281,13 @@ const argv = yargs(hideBin(process.argv))
                     alias: 'x',
                     type: 'number',
                     description: 'Maximum allowed DNS lookups',
-                    default: 50
+                    default: 10
+                })
+                .option('max-void-lookups', {
+                    alias: 'z',
+                    type: 'number',
+                    description: 'Maximum allowed empty DNS lookups',
+                    default: 2
                 });
         },
         argv => {

--- a/cli.md
+++ b/cli.md
@@ -59,7 +59,8 @@ Where
 -   `--mta hostname` or `-m hostname` is the server hostname doing the validation checks. Defaults to `os.hostname()`
 -   `--dns-cache /path/to/dns.json` or `-n path` is the path to a file with cached DNS query responses. If this file is provided then no actual DNS requests are performed, only cached values from this file are used.
 -   `--verbose` or `-v` if this flag is set then mailauth writes some debugging info to standard error
--   `--max-lookups nr` or `-x nr` defines the allowed DNS lookup limit for SPF checks. Defaults to 50.
+-   `--max-lookups nr` or `-x nr` defines the allowed DNS lookup limit for SPF checks. Defaults to 10.
+-   `--max-void-lookups nr` or `-z nr` defines the allowed DNS lookup limit for SPF checks. Defaults to 2.
 
 **Example**
 
@@ -187,14 +188,15 @@ Where
 -   `--dns-cache /path/to/dns.json` or `-n path` is the path to a file with cached DNS query responses. If this file is provided then no actual DNS requests are performed, only cached values from this file are used.
 -   `--verbose` or `-v` if this flag is set then mailauth writes some debugging info to standard error
 -   `--headers-only` or `-o` If set return SPF authentication header only. Default is to return a JSON structure.
--   `--max-lookups nr` or `-x nr` defines the allowed DNS lookup limit for SPF checks. Defaults to 50.
+-   `--max-lookups nr` or `-x nr` defines the allowed DNS lookup limit for SPF checks. Defaults to 10.
+-   `--max-void-lookups nr` or `-z nr` defines the allowed DNS lookup limit for SPF checks. Defaults to 2.
 
 **Example**
 
 ```
 $ mailauth spf --verbose -f andris@wildduck.email -i 217.146.76.20
 Checking SPF for andris@wildduck.email
-Maximum DNS lookups: 50
+Maximum DNS lookups: 10
 --------
 DNS query for TXT wildduck.email: [["v=spf1 mx a -all"]]
 DNS query for MX wildduck.email: [{"exchange":"mail.wildduck.email","priority":1}]

--- a/examples/authenticate.js
+++ b/examples/authenticate.js
@@ -23,7 +23,8 @@ const main = async () => {
             console.log('DNS', rr, name);
             return await dns.promises.resolve(name, rr);
         },
-        maxResolveCount: 10
+        maxResolveCount: 10,
+        maxVoidCount: 2
     });
 
     console.log(JSON.stringify(res, false, 2));

--- a/examples/dns-cache.json
+++ b/examples/dns-cache.json
@@ -5,5 +5,71 @@
 
     "example.com": {
         "TXT": [["v=spf1 include:_spf.google.com include:sendgrid.net", " include:servers.mcsv.net include:servers.outfunnel.com ip4:18.194.223.2 ~all"]]
+    },
+
+    "exploding.mx": {
+        "TXT": [["v=spf1 mx -all"]],
+        "MX": [
+            { "exchange": "mx1.exploding.mx", "priority": 1 },
+            { "exchange": "mx2.exploding.mx", "priority": 2 },
+            { "exchange": "mx3.exploding.mx", "priority": 3 },
+            { "exchange": "mx4.exploding.mx", "priority": 4 },
+            { "exchange": "mx5.exploding.mx", "priority": 5 },
+            { "exchange": "mx6.exploding.mx", "priority": 6 },
+            { "exchange": "mx7.exploding.mx", "priority": 7 },
+            { "exchange": "mx8.exploding.mx", "priority": 8 },
+            { "exchange": "mx9.exploding.mx", "priority": 9 },
+            { "exchange": "mx10.exploding.mx", "priority": 10 },
+            { "exchange": "mx11.exploding.mx", "priority": 11 },
+            { "exchange": "mx12.exploding.mx", "priority": 12 }
+        ]
+    },
+
+    "mx1.exploding.mx": {
+        "A": [["1.2.3.1"]]
+    },
+
+    "mx2.exploding.mx": {
+        "A": [["1.2.3.2"]]
+    },
+
+    "mx3.exploding.mx": {
+        "A": [["1.2.3.3"]]
+    },
+
+    "mx4.exploding.mx": {
+        "A": [["1.2.3.4"]]
+    },
+
+    "mx5.exploding.mx": {
+        "A": [["1.2.3.5"]]
+    },
+
+    "mx6.exploding.mx": {
+        "A": [["1.2.3.6"]]
+    },
+
+    "mx7.exploding.mx": {
+        "A": [["1.2.3.7"]]
+    },
+
+    "_mx8.exploding.mx": {
+        "A": [["1.2.3.8"]]
+    },
+
+    "mx9.exploding.mx": {
+        "A": [["1.2.3.9"]]
+    },
+
+    "mx10.exploding.mx": {
+        "A": [["1.2.3.10"]]
+    },
+
+    "mx11.exploding.mx": {
+        "A": [["1.2.3.11"]]
+    },
+
+    "mx12.exploding.mx": {
+        "A": [["1.2.3.12"]]
     }
 }

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -35,6 +35,10 @@ const cmd = async argv => {
         opts.maxResolveCount = argv.maxLookups;
     }
 
+    if (argv.maxVoidLookups) {
+        opts.maxVoidCount = argv.maxVoidLookups;
+    }
+
     for (let key of ['mta', 'helo', 'sender']) {
         if (argv[key]) {
             opts[key] = argv[key];

--- a/lib/commands/spf.js
+++ b/lib/commands/spf.js
@@ -28,6 +28,10 @@ const cmd = async argv => {
         opts.maxResolveCount = argv.maxLookups;
     }
 
+    if (argv.maxVoidLookups) {
+        opts.maxVoidCount = argv.maxVoidLookups;
+    }
+
     for (let key of ['sender', 'helo', 'mta']) {
         if (argv[key]) {
             opts[key] = argv[key];

--- a/lib/dkim/body/relaxed.js
+++ b/lib/dkim/body/relaxed.js
@@ -266,27 +266,3 @@ class RelaxedHash {
 }
 
 module.exports = { RelaxedHash };
-
-/*
-let fs = require('fs');
-
-const getBody = message => {
-    message = message.toString('binary');
-    let match = message.match(/\r?\n\r?\n/);
-    if (match) {
-        message = message.substr(match.index + match[0].length);
-    }
-    return Buffer.from(message, 'binary');
-};
-
-let s = fs.readFileSync(process.argv[2]);
-
-let k = new RelaxedHash('rsa-sha256', -1);
-
-for (let byte of getBody(s)) {
-    k.update(Buffer.from([byte]));
-}
-
-console.error(k.digest('base64'));
-console.error(k.byteLength, k.bodyHashedBytes);
-*/

--- a/lib/spf/index.js
+++ b/lib/spf/index.js
@@ -8,7 +8,8 @@ const Joi = require('joi');
 const domainSchema = Joi.string().domain({ allowUnicode: false, tlds: false });
 const { formatAuthHeaderRow, escapeCommentValue } = require('../tools');
 
-const MAX_RESOLVE_COUNT = 50;
+const MAX_RESOLVE_COUNT = 10;
+const MAX_VOID_COUNT = 2;
 
 const formatHeaders = result => {
     let header = `Received-SPF: ${result.status.result}${result.status.comment ? ` (${escapeCommentValue(result.status.comment)})` : ''} client-ip=${
@@ -19,23 +20,24 @@ const formatHeaders = result => {
 };
 
 // DNS resolver method
-let limitedResolver = (resolver, maxResolveCount) => {
+let limitedResolver = (resolver, maxResolveCount, maxVoidCount, ignoreFirst) => {
     let resolveCount = 0;
+    let voidCount = 0;
+
+    let subResolveCounts = {};
+    let firstCounted = !ignoreFirst;
+
     maxResolveCount = maxResolveCount || MAX_RESOLVE_COUNT;
+    maxVoidCount = maxVoidCount || MAX_VOID_COUNT;
 
-    return async (domain, type) => {
-        if (!domain && type === 'resolveCount') {
-            // special condition to get the counter
-            return resolveCount;
-        }
-
-        if (!domain && type === 'resolveLimit') {
-            // special condition to get the limit
-            return maxResolveCount;
-        }
-
+    let resolverFunc = async (domain, type) => {
         // do not allow to make more that MAX_RESOLVE_COUNT DNS requests per SPF check
-        resolveCount++;
+
+        if (firstCounted) {
+            resolveCount++;
+        } else {
+            firstCounted = true;
+        }
 
         if (resolveCount > maxResolveCount) {
             let error = new Error('Too many DNS requests');
@@ -65,8 +67,17 @@ let limitedResolver = (resolver, maxResolveCount) => {
         } catch (err) {
             switch (err.code) {
                 case 'ENOTFOUND':
-                case 'ENODATA':
+                case 'ENODATA': {
+                    voidCount++;
+                    if (voidCount > maxVoidCount) {
+                        err.spfResult = {
+                            error: 'permerror',
+                            text: 'Too many void DNS results'
+                        };
+                        throw err;
+                    }
                     return [];
+                }
 
                 case 'ETIMEOUT':
                     err.spfResult = {
@@ -80,6 +91,21 @@ let limitedResolver = (resolver, maxResolveCount) => {
             }
         }
     };
+
+    resolverFunc.updateSubQueries = (type, count) => {
+        if (!subResolveCounts[type]) {
+            subResolveCounts[type] = count;
+        } else {
+            subResolveCounts[type] += count;
+        }
+    };
+
+    resolverFunc.getResolveCount = () => resolveCount;
+    resolverFunc.getResolveLimit = () => maxResolveCount;
+    resolverFunc.getSubResolveCounts = () => subResolveCounts;
+    resolverFunc.getVoidCount = () => voidCount;
+
+    return resolverFunc;
 };
 
 /**
@@ -89,10 +115,11 @@ let limitedResolver = (resolver, maxResolveCount) => {
  * @param {String} opts.ip Client IP address
  * @param {String} opts.helo Client EHLO/HELO hostname
  * @param {String} [opts.mta] Hostname of the MTA or MX server that processes the message
- * @param {String} [opts.maxResolveCount=50] Maximum DNS lookups allowed
+ * @param {String} [opts.maxResolveCount=10] Maximum DNS lookups allowed
+ * @param {String} [opts.maxVoidCount=2] Maximum empty DNS lookups allowed
  */
 const verify = async opts => {
-    let { sender, ip, helo, mta, maxResolveCount, resolver } = opts || {};
+    let { sender, ip, helo, mta, maxResolveCount, maxVoidCount, resolver } = opts || {};
 
     mta = mta || os.hostname();
 
@@ -125,7 +152,7 @@ const verify = async opts => {
         }
     };
 
-    let verifyResolver = limitedResolver(resolver, maxResolveCount);
+    let verifyResolver = limitedResolver(resolver, maxResolveCount, maxVoidCount, true);
 
     let result;
     try {
@@ -146,7 +173,10 @@ const verify = async opts => {
             helo,
 
             // generate DNS handler
-            resolver: verifyResolver
+            resolver: verifyResolver,
+
+            // allow to create sub resolvers
+            createSubResolver: () => limitedResolver(resolver, maxResolveCount, maxVoidCount)
         });
     } catch (err) {
         if (err.spfResult) {
@@ -161,8 +191,10 @@ const verify = async opts => {
 
     if (result && typeof result === 'object') {
         result.lookups = {
-            limit: await verifyResolver(false, 'resolveLimit'),
-            count: await verifyResolver(false, 'resolveCount')
+            limit: verifyResolver.getResolveLimit(),
+            count: verifyResolver.getResolveCount(),
+            void: verifyResolver.getVoidCount(),
+            subqueries: verifyResolver.getSubResolveCounts()
         };
     }
 

--- a/lib/spf/spf-verify.js
+++ b/lib/spf/spf-verify.js
@@ -5,6 +5,9 @@ const net = require('net');
 const macro = require('./macro');
 const dns = require('dns').promises;
 const ipaddr = require('ipaddr.js');
+const { getPtrHostname, formatDomain } = require('../tools');
+
+const LIMIT_PTR_RESOLVE_RECORDS = 10;
 
 const matchIp = (addr, range) => {
     if (/\/\d+$/.test(range)) {
@@ -357,17 +360,26 @@ const spfVerify = async (domain, opts) => {
 
                         let mxList = await resolver(mxDomain, 'MX');
                         if (mxList) {
-                            mxList = mxList.sort((a, b) => a.priority - b.priority);
-                            for (let mx of mxList) {
-                                if (mx.exchange) {
-                                    let responses = await resolver(mx.exchange, net.isIPv6(opts.ip) ? 'AAAA' : 'A');
-                                    if (responses) {
-                                        for (let a of responses) {
-                                            if (matchIp(addr, a + cidr)) {
-                                                return { type, val: mx.exchange, qualifier };
+                            // MX resolver has separate counter
+                            let subResolver = typeof opts.createSubResolver === 'function' ? opts.createSubResolver() : resolver;
+                            try {
+                                mxList = mxList.sort((a, b) => a.priority - b.priority);
+                                for (let mx of mxList) {
+                                    if (mx.exchange) {
+                                        let responses = await subResolver(mx.exchange, net.isIPv6(opts.ip) ? 'AAAA' : 'A');
+                                        if (responses) {
+                                            for (let a of responses) {
+                                                if (matchIp(addr, a + cidr)) {
+                                                    return { type, val: mx.exchange, qualifier };
+                                                }
                                             }
                                         }
                                     }
+                                }
+                            } finally {
+                                if (typeof resolver.updateSubQueries === 'function') {
+                                    resolver.updateSubQueries('mx', subResolver.getResolveCount());
+                                    resolver.updateSubQueries('mx:void', subResolver.getVoidCount());
                                 }
                             }
                         }
@@ -391,7 +403,73 @@ const spfVerify = async (domain, opts) => {
                     break;
 
                 case 'ptr':
-                    // ignore, not supported
+                    {
+                        let { cidr4, cidr6 } = parseCidrValue(val, false, type);
+                        if (cidr4 || cidr6) {
+                            let err = new Error('SPF failure');
+                            err.spfResult = { error: 'permerror', text: `invalid domain-spec definition: ${val}` };
+                            throw err;
+                        }
+
+                        let ptrDomain;
+                        if (val) {
+                            ptrDomain = macro(val, opts);
+                        } else {
+                            ptrDomain = macro('%{d}', opts);
+                        }
+                        ptrDomain = formatDomain(ptrDomain);
+
+                        // Step 1. Resolve PTR hostnames
+                        let ptrValues;
+                        if (opts._resolvedPtr) {
+                            ptrValues = opts._resolvedPtr;
+                        } else {
+                            let responses = await resolver(getPtrHostname(addr), 'PTR');
+                            opts._resolvedPtr = ptrValues = responses && responses.length ? responses : [];
+                        }
+
+                        // PTR resolver has separate counter
+                        let subResolver = typeof opts.createSubResolver === 'function' ? opts.createSubResolver() : resolver;
+
+                        let resolvers = [];
+                        for (let ptrValue of ptrValues) {
+                            if (resolvers.length < LIMIT_PTR_RESOLVE_RECORDS) {
+                                // resolve up to 10 PTR A/AAAA records
+                                // https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4
+                                resolvers.push(subResolver(ptrValue, net.isIPv6(opts.ip) ? 'AAAA' : 'A'));
+                            }
+                        }
+
+                        // Step 2. Validate PTR hostnames by reverse resolving these
+                        let validatedPtrRecords = [];
+                        let results = await Promise.allSettled(resolvers);
+
+                        if (typeof resolver.updateSubQueries === 'function') {
+                            resolver.updateSubQueries('ptr', subResolver.getResolveCount());
+                            resolver.updateSubQueries('ptr:void', subResolver.getVoidCount());
+                        }
+
+                        for (let i = 0; i < results.length; i++) {
+                            let result = results[i];
+                            let ptrHostname = ptrValues[i];
+                            if (
+                                result.status === 'fulfilled' &&
+                                Array.isArray(result.value) &&
+                                result.value.map(val => ipaddr.parse(val).toNormalizedString()).includes(addr.toNormalizedString())
+                            ) {
+                                validatedPtrRecords.push(ptrHostname);
+                            }
+                        }
+
+                        // Step 3. Check subdomain alignment
+                        for (let ptrRecord of validatedPtrRecords) {
+                            let formattedPtrRecord = formatDomain(ptrRecord);
+
+                            if (formattedPtrRecord === ptrDomain || formattedPtrRecord.substr(-(ptrDomain.length + 1)) === `.${ptrDomain}`) {
+                                return { type, val: ptrRecord, qualifier };
+                            }
+                        }
+                    }
                     break;
             }
         }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -470,6 +470,21 @@ const validateAlgorithm = (algorithm, strict) => {
     }
 };
 
+const getPtrHostname = parsedAddr => {
+    let bytes = parsedAddr.toByteArray();
+    if (bytes.length === 4) {
+        return `${bytes
+            .map(a => a.toString(10))
+            .reverse()
+            .join('.')}.in-addr.arpa`;
+    } else {
+        return `${bytes
+            .flatMap(a => a.toString(16).padStart(2, '0').split(''))
+            .reverse()
+            .join('.')}.ip6.arpa`;
+    }
+};
+
 module.exports = {
     writeToStream,
     parseHeaders,
@@ -491,5 +506,7 @@ module.exports = {
     getAlignment,
 
     formatRelaxedLine,
-    formatDomain
+    formatDomain,
+
+    getPtrHostname
 };

--- a/man/man.md
+++ b/man/man.md
@@ -103,7 +103,10 @@ content is read from standard input.
     Return signing headers only. By default, the entire message is printed to the console. (`sign`, `seal`, `spf`)
 
 -   `--max-lookups`, `-x`
-    How many DNS lookups allowed for SPF validation. Defaults to 50. (`report`, `spf`)
+    How many DNS lookups allowed for SPF validation. Defaults to 10. (`report`, `spf`)
+
+-   `--max-void-lookups`, `-z`
+    How many empty DNS lookups allowed for SPF validation. Defaults to 2. (`report`, `spf`)
 
 ## DNS CACHE
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "eslint-config-nodemailer": "1.2.0",
         "eslint-config-prettier": "8.5.0",
         "js-yaml": "4.1.0",
-        "license-report": "5.0.2",
+        "license-report": "6.0.0",
         "marked": "0.7.0",
         "marked-man": "0.7.0",
         "mbox-reader": "1.1.5",

--- a/test/spf/rfc-suite-test.js
+++ b/test/spf/rfc-suite-test.js
@@ -20,7 +20,8 @@ const ignoreTests = [
     /^non-ascii-non-spf$/,
 
     // PTR not supported
-    /^ptr-/,
+    //    /^ptr-/,
+
     /^bytes-bug$/,
 
     // this implementation is more relaxed
@@ -42,10 +43,10 @@ const ignoreTests = [
     // macro domain implementation not compatible
     /^invalid-hello-macro$/,
     /^hello-domain-literal$/,
-    /^require-valid-helo$/,
+    /^require-valid-helo$/
 
     // implementation has higher limits
-    /-limit$/
+    // /-limit$/
 ];
 
 let replyErr = code => {
@@ -67,6 +68,13 @@ let replyErr = code => {
 let getResolver = zonedata => {
     let resolver = async (domain, type) => {
         domain = domain.toLowerCase().trim();
+
+        // make sure we can run case insensitive queries
+        for (let key of Object.keys(zonedata)) {
+            if (key.toLowerCase() !== key && !zonedata[key.toLowerCase()]) {
+                zonedata[key.toLowerCase()] = zonedata[key];
+            }
+        }
 
         if (zonedata[domain]) {
             let list = zonedata[domain].filter(e => e && e[type]);


### PR DESCRIPTION
* Support for ptr SPF mechanism
* Use DNS query limits for SPF as defined in [rfc7208#section-4.6.4](https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4). DNS queries for SPF are limited to 10.
* New option `maxVoidCount` and cli argument `--max-void-lookups / -z` (defaults to 2)