### PR TITLE
Extracted get-dmarc-record into separate function

### DIFF
--- a/examples/get-dmarc-record.js
+++ b/examples/get-dmarc-record.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const getDmarcRecord = require('../lib/dmarc/get-dmarc-record');
+
+const domain = (process.argv[2] || '').trim();
+
+if (!domain) {
+    console.log('Provide domain name as an argument');
+    console.log('$ node get-dmarc-record.js domain.tld');
+    process.exit();
+}
+
+getDmarcRecord(domain).then(console.log);

--- a/lib/dmarc/get-dmarc-record.js
+++ b/lib/dmarc/get-dmarc-record.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const psl = require('psl');
+const dns = require('dns').promises;
+
+const resolveTxt = async (domain, resolver) => {
+    try {
+        let txt = await resolver(`_dmarc.${domain}`, 'TXT');
+        if (!txt || !txt.length) {
+            return false;
+        }
+
+        txt = txt.map(row => row.join('').trim()).filter(row => /^v=DMARC1\b/i.test(row));
+
+        if (txt.length !== 1) {
+            //no records or multiple records yield in no policy
+            return false;
+        }
+
+        return txt[0];
+    } catch (err) {
+        if (err.code === 'ENOTFOUND' || err.code === 'ENODATA') {
+            return false;
+        }
+        throw err;
+    }
+};
+
+const getDmarcRecord = async (domain, resolver) => {
+    resolver = resolver || dns.resolve;
+
+    let txt = await resolveTxt(domain, resolver);
+    let isOrgRecord = false;
+
+    if (!txt) {
+        let orgDomain = psl.get(domain);
+        if (orgDomain !== domain) {
+            // try org domain as well
+            txt = await resolveTxt(orgDomain, resolver);
+            isOrgRecord = true;
+        }
+    }
+
+    if (!txt) {
+        return false;
+    }
+
+    let parsed = Object.fromEntries(
+        txt
+            .split(';')
+            .map(e => e.trim())
+            .filter(e => e)
+            .map(e => {
+                let splitPos = e.indexOf('=');
+                if (splitPos < 0) {
+                    return [e.toLowerCase().trim(), false];
+                } else if (splitPos === 0) {
+                    return [false, e];
+                }
+                let key = e.substr(0, splitPos).toLowerCase().trim();
+                let val = e.substr(splitPos + 1);
+                if (['pct', 'ri'].includes(key)) {
+                    val = parseInt(val, 10) || 0;
+                }
+                return [key, val];
+            })
+    );
+
+    parsed.rr = txt;
+    parsed.isOrgRecord = isOrgRecord;
+
+    return parsed;
+};
+
+module.exports = getDmarcRecord;

--- a/lib/dmarc/verify.js
+++ b/lib/dmarc/verify.js
@@ -4,73 +4,7 @@ const dns = require('dns').promises;
 const punycode = require('punycode/');
 const psl = require('psl');
 const { formatAuthHeaderRow, getAlignment } = require('../tools');
-
-const resolveTxt = async (domain, resolver) => {
-    try {
-        let txt = await resolver(`_dmarc.${domain}`, 'TXT');
-        if (!txt || !txt.length) {
-            return false;
-        }
-
-        txt = txt.map(row => row.join('').trim()).filter(row => /^v=DMARC1\b/i.test(row));
-
-        if (txt.length !== 1) {
-            //no records or multiple records yield in no policy
-            return false;
-        }
-
-        return txt[0];
-    } catch (err) {
-        if (err.code === 'ENOTFOUND' || err.code === 'ENODATA') {
-            return false;
-        }
-        throw err;
-    }
-};
-
-const getDmarcRecord = async (domain, resolver) => {
-    let txt = await resolveTxt(domain, resolver);
-    let isOrgRecord = false;
-
-    if (!txt) {
-        let orgDomain = psl.get(domain);
-        if (orgDomain !== domain) {
-            // try org domain as well
-            txt = await resolveTxt(orgDomain, resolver);
-            isOrgRecord = true;
-        }
-    }
-
-    if (!txt) {
-        return false;
-    }
-
-    let parsed = Object.fromEntries(
-        txt
-            .split(';')
-            .map(e => e.trim())
-            .filter(e => e)
-            .map(e => {
-                let splitPos = e.indexOf('=');
-                if (splitPos < 0) {
-                    return [e.toLowerCase().trim(), false];
-                } else if (splitPos === 0) {
-                    return [false, e];
-                }
-                let key = e.substr(0, splitPos).toLowerCase().trim();
-                let val = e.substr(splitPos + 1);
-                if (['pct', 'ri'].includes(key)) {
-                    val = parseInt(val, 10) || 0;
-                }
-                return [key, val];
-            })
-    );
-
-    parsed.rr = txt;
-    parsed.isOrgRecord = isOrgRecord;
-
-    return parsed;
-};
+const getDmarcRecord = require('./get-dmarc-record');
 
 const verifyDmarc = async opts => {
     let { headerFrom, spfDomains, dkimDomains, resolver, arcResult } = opts;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "homepage": "https://github.com/postalsys/mailauth",
     "devDependencies": {
         "chai": "4.3.7",
-        "eslint": "8.32.0",
+        "eslint": "8.33.0",
         "eslint-config-nodemailer": "1.2.0",
         "eslint-config-prettier": "8.6.0",
         "js-yaml": "4.1.0",
@@ -46,11 +46,11 @@
     },
     "dependencies": {
         "@postalsys/vmc": "1.0.6",
-        "fast-xml-parser": "4.0.15",
+        "fast-xml-parser": "4.1.1",
         "ipaddr.js": "2.0.1",
         "joi": "17.7.0",
-        "libmime": "5.2.0",
-        "nodemailer": "6.9.0",
+        "libmime": "5.2.1",
+        "nodemailer": "6.9.1",
         "psl": "1.9.0",
         "punycode": "2.3.0",
         "yargs": "17.6.2"


### PR DESCRIPTION
Extracted `getDmarcRecord` into separate file

### External usage

```
const getDmarcRecord = require('mailauth/lib/dmarc/get-dmarc-record');
const dmarcRecord = getDmarcRecord("ethereal.email");
console.log(dmarcRecord);
```

**Output**

```
{
  v: 'DMARC1',
  p: 'none',
  pct: 100,
  rua: 'mailto:re+joqy8fpatm3@dmarc.postmarkapp.com',
  sp: 'none',
  aspf: 'r',
  rr: 'v=DMARC1; p=none; pct=100; rua=mailto:re+joqy8fpatm3@dmarc.postmarkapp.com; sp=none; aspf=r;',
  isOrgRecord: false
}
```