### PR TITLE
Return rr for SPF query even if the result was neutral

### DIFF
--- a/lib/spf/index.js
+++ b/lib/spf/index.js
@@ -86,6 +86,13 @@ let limitedResolver = (resolver, maxResolveCount, maxVoidCount, ignoreFirst) => 
                     };
                     throw err;
 
+                case 'EREFUSED':
+                    err.spfResult = {
+                        error: 'temperror',
+                        text: `DNS request refused by server when resolving ${domain}`
+                    };
+                    throw err;
+
                 default:
                     throw err;
             }

--- a/lib/spf/spf-verify.js
+++ b/lib/spf/spf-verify.js
@@ -479,8 +479,15 @@ const spfVerify = async (domain, opts) => {
 
     try {
         let res = await getResult();
+
         if (res && spfRr) {
             res.rr = spfRr;
+        } else if (spfRr) {
+            res = {
+                // default is neutral
+                qualifier: '?',
+                rr: spfRr
+            };
         }
         return res;
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "homepage": "https://github.com/postalsys/mailauth",
     "devDependencies": {
         "chai": "4.3.7",
-        "eslint": "8.37.0",
+        "eslint": "8.38.0",
         "eslint-config-nodemailer": "1.2.0",
         "eslint-config-prettier": "8.8.0",
         "js-yaml": "4.1.0",
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@postalsys/vmc": "1.0.6",
-        "fast-xml-parser": "4.1.3",
+        "fast-xml-parser": "4.2.0",
         "ipaddr.js": "2.0.1",
         "joi": "17.9.1",
         "libmime": "5.2.1",


### PR DESCRIPTION
Return rr for SPF query even if the result was neutral