### PR TITLE
Added boolean option bimiWithAlignedDkim

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,9 @@ const { bimi } = await authenticate(
         ip: '217.146.67.33', // SMTP client IP
         helo: 'uvn-67-33.tll01.zonevs.eu', // EHLO/HELO hostname
         mta: 'mx.ethereal.email', // server processing this message, defaults to os.hostname()
-        sender: 'andris@ekiri.ee' // MAIL FROM address
+        sender: 'andris@ekiri.ee', // MAIL FROM address
+
+        bimiWithAlignedDkim: false // If true then ignores SPF in DMARC and requires a valid DKIM signature
     }
 );
 if (bimi?.location) {

--- a/examples/authenticate.js
+++ b/examples/authenticate.js
@@ -24,7 +24,9 @@ const main = async () => {
             return await dns.promises.resolve(name, rr);
         },
         maxResolveCount: 10,
-        maxVoidCount: 2
+        maxVoidCount: 2,
+
+        bimiWithAlignedDkim: true
     });
 
     console.log(JSON.stringify(res, false, 2));

--- a/lib/bimi/index.js
+++ b/lib/bimi/index.js
@@ -15,7 +15,7 @@ const { vmc } = require('@postalsys/vmc');
 const { validateSvg } = require('./validate-svg');
 
 const lookup = async data => {
-    let { dmarc, headers, resolver } = data;
+    let { dmarc, headers, resolver, bimiWithAlignedDkim } = data;
     let headerRows = (headers && headers.parsed) || [];
 
     resolver = resolver || dns.promises.resolve;
@@ -37,6 +37,13 @@ const lookup = async data => {
     if (dmarc.policy === 'none' || (dmarc.policy === 'quarantine' && dmarc.pct && dmarc.pct < 100)) {
         response.status.result = 'skipped';
         response.status.comment = 'too lax DMARC policy';
+        response.info = formatAuthHeaderRow('bimi', response.status);
+        return response;
+    }
+
+    if (!dmarc.alignment?.dkim?.result && bimiWithAlignedDkim) {
+        response.status.result = 'skipped';
+        response.status.comment = 'Aligned DKIM signature required';
         response.info = formatAuthHeaderRow('bimi', response.status);
         return response;
     }

--- a/lib/mailauth.js
+++ b/lib/mailauth.js
@@ -133,6 +133,7 @@ const authenticate = async (input, opts) => {
         bimiResult = await bimi({
             dmarc: dmarcResult,
             headers: dkimResult.headers,
+            bimiWithAlignedDkim: opts.bimiWithAlignedDkim,
             resolver: opts.resolver
         });
     }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "homepage": "https://github.com/postalsys/mailauth",
     "devDependencies": {
         "chai": "4.3.7",
-        "eslint": "8.38.0",
+        "eslint": "8.42.0",
         "eslint-config-nodemailer": "1.2.0",
         "eslint-config-prettier": "8.8.0",
         "js-yaml": "4.1.0",
-        "license-report": "6.3.0",
+        "license-report": "6.4.0",
         "marked": "0.7.0",
         "marked-man": "0.7.0",
         "mbox-reader": "1.1.5",
@@ -46,14 +46,14 @@
     },
     "dependencies": {
         "@postalsys/vmc": "1.0.6",
-        "fast-xml-parser": "4.2.0",
-        "ipaddr.js": "2.0.1",
-        "joi": "17.9.1",
+        "fast-xml-parser": "4.2.4",
+        "ipaddr.js": "2.1.0",
+        "joi": "17.9.2",
         "libmime": "5.2.1",
-        "nodemailer": "6.9.1",
+        "nodemailer": "6.9.3",
         "psl": "1.9.0",
         "punycode": "2.3.0",
-        "yargs": "17.7.1"
+        "yargs": "17.7.2"
     },
     "engines": {
         "node": ">=16.0.0"

--- a/test/bimi-test.js
+++ b/test/bimi-test.js
@@ -159,7 +159,7 @@ describe('BIMI Tests', () => {
         expect(res?.location).to.equal('https://cldup.com/a6t0ORNG2z.svg');
     });
 
-    it.only('Should resolve BIMI location with valid DKIM', async () => {
+    it('Should resolve BIMI location with valid DKIM', async () => {
         let res = await bimi({
             dmarc: {
                 status: {
@@ -197,7 +197,7 @@ describe('BIMI Tests', () => {
         expect(res?.location).to.equal('https://cldup.com/a6t0ORNG2z.svg');
     });
 
-    it.only('Should fail resolving BIMI location without valid DKIM', async () => {
+    it('Should fail resolving BIMI location without valid DKIM', async () => {
         let res = await bimi({
             dmarc: {
                 status: {
@@ -233,7 +233,7 @@ describe('BIMI Tests', () => {
         expect(res?.status?.result).to.equal('skipped');
     });
 
-    it.only('Should not fail resolving BIMI location without valid DKIM', async () => {
+    it('Should not fail resolving BIMI location without valid DKIM', async () => {
         let res = await bimi({
             dmarc: {
                 status: {


### PR DESCRIPTION
If `bimiWithAlignedDkim` is `true`, then BIMI is validated only with an aligned DKIM signature. Having only a passing SPF is not enough.