### PR TITLE
fix: fixed orgDomain lookup (closes #60)

### DIFF
--- a/lib/dmarc/get-dmarc-record.js
+++ b/lib/dmarc/get-dmarc-record.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const psl = require('psl');
 const dns = require('node:dns').promises;
+const { getOrgDomain } = require('../../lib/tools');
 
 const resolveTxt = async (domain, resolver) => {
     try {
@@ -33,8 +33,8 @@ const getDmarcRecord = async (domain, resolver) => {
     let isOrgRecord = false;
 
     if (!txt) {
-        let orgDomain = psl.get(domain);
-        if (orgDomain !== domain) {
+        let orgDomain = getOrgDomain(domain);
+        if (orgDomain.toLowerCase() !== domain.toLowerCase()) {
             // try org domain as well
             txt = await resolveTxt(orgDomain, resolver);
             isOrgRecord = true;

--- a/lib/dmarc/verify.js
+++ b/lib/dmarc/verify.js
@@ -2,8 +2,7 @@
 
 const dns = require('node:dns').promises;
 const punycode = require('punycode/');
-const psl = require('psl');
-const { formatAuthHeaderRow, getAlignment } = require('../tools');
+const { formatAuthHeaderRow, getAlignment, getOrgDomain } = require('../tools');
 const getDmarcRecord = require('./get-dmarc-record');
 
 const verifyDmarc = async opts => {
@@ -41,14 +40,14 @@ const verifyDmarc = async opts => {
         return response;
     };
 
-    let orgDomain = psl.get(domain);
+    let orgDomain = getOrgDomain(domain);
 
     let status = {
         result: 'neutral',
         comment: false,
         // ptype properties
         header: {
-            from: orgDomain || domain
+            from: orgDomain
         }
     };
 
@@ -58,14 +57,14 @@ const verifyDmarc = async opts => {
     } catch (err) {
         // temperror?
         status.result = 'temperror';
-        return formatResponse({ status, domain: orgDomain || domain, error: err.message });
+        return formatResponse({ status, domain: orgDomain, error: err.message });
     }
 
     if (!dmarcRecord) {
         // nothing to do here
         // none
         status.result = 'none';
-        return formatResponse({ status, domain: orgDomain || domain });
+        return formatResponse({ status, domain: orgDomain });
     }
 
     status.header = status.header || {};
@@ -93,7 +92,7 @@ const verifyDmarc = async opts => {
 
     return formatResponse({
         status,
-        domain: orgDomain || domain,
+        domain: orgDomain,
         policy,
         p: dmarcRecord.p,
         sp: dmarcRecord.sp || dmarcRecord.p,

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -8,9 +8,9 @@ const libmime = require('libmime');
 const dns = require('node:dns').promises;
 const crypto = require('node:crypto');
 const https = require('node:https');
+const { parseDomain, ParseResultType } = require('parse-domain');
 const packageData = require('../package');
 const parseDkimHeaders = require('./parse-dkim-headers');
-const psl = require('psl');
 const Joi = require('joi');
 const base64Schema = Joi.string().base64({ paddingRequired: false });
 
@@ -483,7 +483,7 @@ const getAlignment = (fromDomain, domainList, strict) => {
     if (strict) {
         fromDomain = formatDomain(fromDomain);
         for (let entry of domainList) {
-            let domain = formatDomain(psl.get(entry.domain) || entry.domain);
+            let domain = formatDomain(getOrgDomain(entry.domain));
             if (formatDomain(domain) === fromDomain) {
                 return entry;
             }
@@ -491,9 +491,9 @@ const getAlignment = (fromDomain, domainList, strict) => {
     }
 
     // match org domains
-    fromDomain = formatDomain(psl.get(fromDomain) || fromDomain);
+    fromDomain = formatDomain(getOrgDomain(fromDomain));
     for (let entry of domainList) {
-        let domain = formatDomain(psl.get(entry.domain) || entry.domain);
+        let domain = formatDomain(getOrgDomain(entry.domain));
         if (domain === fromDomain) {
             return entry;
         }
@@ -565,6 +565,19 @@ function getCurTime(timeValue) {
     return new Date();
 }
 
+function getOrgDomain(name) {
+    const parseResult = parseDomain(name);
+    return (
+        parseResult?.type === ParseResultType?.Listed &&
+        parseResult?.icann?.domain &&
+        parseResult?.icann?.topLevelDomains
+            ? `${parseResult.icann.domain}.${parseResult.icann.topLevelDomains.join(
+                  '.'
+                )}`
+            : name
+    );
+}
+
 module.exports = {
     writeToStream,
     parseHeaders,
@@ -591,5 +604,7 @@ module.exports = {
 
     getPtrHostname,
 
-    getCurTime
+    getCurTime,
+
+    getOrgDomain
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "joi": "17.13.1",
                 "libmime": "5.3.5",
                 "nodemailer": "6.9.13",
-                "psl": "1.9.0",
+                "parse-domain": "5.0.0",
                 "punycode": "2.3.1",
                 "undici": "5.28.4",
                 "uuid": "9.0.1",
@@ -818,6 +818,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
             "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+            "deprecated": "This package is no longer supported.",
             "dev": true,
             "dependencies": {
                 "delegates": "^1.0.0",
@@ -989,12 +990,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -1045,16 +1046,16 @@
             }
         },
         "node_modules/cacache/node_modules/glob": {
-            "version": "10.3.15",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.15.tgz",
-            "integrity": "sha512-0c6RlJt1TICLyvJYIApxb8GsXoai0KUP7AxKKAtsYXdgJR1mGEUa7DgwShbdk1nly0PYoZj01xd4hzbq3fsjpw==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
             "dev": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.6",
-                "minimatch": "^9.0.1",
-                "minipass": "^7.0.4",
-                "path-scurry": "^1.11.0"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
@@ -1082,9 +1083,9 @@
             }
         },
         "node_modules/cacache/node_modules/minipass": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-            "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -1595,7 +1596,6 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "iconv-lite": "^0.6.2"
@@ -1923,9 +1923,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -2038,9 +2038,9 @@
             }
         },
         "node_modules/fs-minipass/node_modules/minipass": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-            "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -2079,6 +2079,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
             "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+            "deprecated": "This package is no longer supported.",
             "dev": true,
             "dependencies": {
                 "aproba": "^1.0.3 || ^2.0.0",
@@ -2139,6 +2140,7 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
             "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -2507,6 +2509,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
@@ -2520,9 +2523,9 @@
             "dev": true
         },
         "node_modules/ini": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-            "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+            "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
             "dev": true,
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -2539,6 +2542,14 @@
             },
             "engines": {
                 "node": ">= 12"
+            }
+        },
+        "node_modules/ip-regex": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/ipaddr.js": {
@@ -2630,6 +2641,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-ip": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+            "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+            "dependencies": {
+                "ip-regex": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-lambda": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
@@ -2718,9 +2740,9 @@
             "dev": true
         },
         "node_modules/jackspeak": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-            "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+            "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
             "dev": true,
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
@@ -3117,12 +3139,12 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
             "dev": true,
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -3213,9 +3235,9 @@
             }
         },
         "node_modules/minipass-fetch/node_modules/minipass": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-            "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -3506,6 +3528,25 @@
                 "tslib": "^2.0.3"
             }
         },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/node-gyp": {
             "version": "9.4.1",
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
@@ -3586,6 +3627,7 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
             "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -3629,6 +3671,7 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -3902,16 +3945,16 @@
             }
         },
         "node_modules/npm-check-updates/node_modules/glob": {
-            "version": "10.3.15",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.15.tgz",
-            "integrity": "sha512-0c6RlJt1TICLyvJYIApxb8GsXoai0KUP7AxKKAtsYXdgJR1mGEUa7DgwShbdk1nly0PYoZj01xd4hzbq3fsjpw==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
             "dev": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.6",
-                "minimatch": "^9.0.1",
-                "minipass": "^7.0.4",
-                "path-scurry": "^1.11.0"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
@@ -3939,9 +3982,9 @@
             }
         },
         "node_modules/npm-check-updates/node_modules/minipass": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-            "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -4089,6 +4132,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
             "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+            "deprecated": "This package is no longer supported.",
             "dev": true,
             "dependencies": {
                 "are-we-there-yet": "^3.0.0",
@@ -4267,6 +4311,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parse-domain": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/parse-domain/-/parse-domain-5.0.0.tgz",
+            "integrity": "sha512-sjvhVD0seIF3IquDLsbOE+6nekYyPzj4mGOMv4r9HIXalOjtTXb1uTZwtpQyp0myIoi9++w2eDqYOlCT5ic3+Q==",
+            "dependencies": {
+                "is-ip": "^3.1.0",
+                "node-fetch": "^2.6.1",
+                "punycode": "^2.1.1"
+            },
+            "bin": {
+                "parse-domain-update": "bin/update.js"
+            }
+        },
         "node_modules/parse-github-url": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
@@ -4426,11 +4483,6 @@
             "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
             "dev": true
         },
-        "node_modules/psl": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4557,6 +4609,7 @@
             "version": "6.0.4",
             "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-6.0.4.tgz",
             "integrity": "sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==",
+            "deprecated": "This package is no longer supported. Please use @npmcli/package-json instead.",
             "dev": true,
             "dependencies": {
                 "glob": "^10.2.2",
@@ -4591,16 +4644,16 @@
             }
         },
         "node_modules/read-package-json/node_modules/glob": {
-            "version": "10.3.15",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.15.tgz",
-            "integrity": "sha512-0c6RlJt1TICLyvJYIApxb8GsXoai0KUP7AxKKAtsYXdgJR1mGEUa7DgwShbdk1nly0PYoZj01xd4hzbq3fsjpw==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
             "dev": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.6",
-                "minimatch": "^9.0.1",
-                "minipass": "^7.0.4",
-                "path-scurry": "^1.11.0"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
@@ -4628,9 +4681,9 @@
             }
         },
         "node_modules/read-package-json/node_modules/minipass": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-            "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -4768,6 +4821,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
@@ -4783,6 +4837,7 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -5063,9 +5118,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
-            "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
+            "version": "3.0.18",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
+            "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
             "dev": true
         },
         "node_modules/split-text-to-chunks": {
@@ -5109,9 +5164,9 @@
             }
         },
         "node_modules/ssri/node_modules/minipass": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-            "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5278,6 +5333,11 @@
             "engines": {
                 "node": ">=8.0"
             }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "node_modules/tslib": {
             "version": "2.6.2",
@@ -5499,6 +5559,20 @@
             "resolved": "https://registry.npmjs.org/visit-values/-/visit-values-2.0.0.tgz",
             "integrity": "sha512-vLFU70y3D915d611GnHYeHkEmq6ZZETzTH4P1hM6I9E3lBwH2VeBBEESe/bGCY+gAyK0qqLFn5bNFpui/GKmww==",
             "dev": true
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "joi": "17.13.1",
         "libmime": "5.3.5",
         "nodemailer": "6.9.13",
-        "psl": "1.9.0",
+        "parse-domain": "5.0.0",
         "punycode": "2.3.1",
         "undici": "5.28.4",
         "uuid": "9.0.1",


### PR DESCRIPTION
With the pull request:

```sh
> require('./lib/dmarc/get-dmarc-record')('pay-dartford-crossing-fine.service.gov.uk').then(console.log)
Promise {
  <pending>,
  [Symbol(async_id_symbol)]: 588,
  [Symbol(trigger_async_id_symbol)]: 582
}
> {
  v: 'DMARC1',
  p: 'reject',
  sp: 'reject',
  fo: '1',
  rua: 'mailto:dmarc-rua@dmarc.service.gov.uk',
  ruf: 'mailto:dmarc-ruf@dmarc.service.gov.uk',
  rr: 'v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk',
  isOrgRecord: true
}
```

Without the pull request:

```sh
> require('mailauth/lib/dmarc/get-dmarc-record')('pay-dartford-crossing-fine.service.gov.uk').then(console.log)
Promise {
  <pending>,
  [Symbol(async_id_symbol)]: 114,
  [Symbol(trigger_async_id_symbol)]: 108
}
> false
```