### PR TITLE
Fix DOS issue on fixLineBuffer

### DIFF
--- a/lib/dkim/body/relaxed.js
+++ b/lib/dkim/body/relaxed.js
@@ -123,23 +123,23 @@ class RelaxedHash {
     }
 
     fixLineBuffer(line) {
-        let resultLine = [];
-
+        // Allocate max possible size
+        const resultLine = Buffer.alloc(line.length * 2);
+        let writeIndex = resultLine.length - 1;
         let nonWspFound = false;
         let prevWsp = false;
-
+        
         for (let i = line.length - 1; i >= 0; i--) {
             if (line[i] === CHAR_LF) {
-                resultLine.unshift(line[i]);
+                resultLine[writeIndex--] = CHAR_LF;
                 if (i === 0 || line[i - 1] !== CHAR_CR) {
-                    // add missing carriage return
-                    resultLine.unshift(CHAR_CR);
+                    resultLine[writeIndex--] = CHAR_CR;
                 }
                 continue;
             }
 
             if (line[i] === CHAR_CR) {
-                resultLine.unshift(line[i]);
+                resultLine[writeIndex--] = CHAR_CR;
                 continue;
             }
 
@@ -151,19 +151,19 @@ class RelaxedHash {
             }
 
             if (prevWsp) {
-                resultLine.unshift(CHAR_SPACE);
+                resultLine[writeIndex--] = CHAR_SPACE;
                 prevWsp = false;
             }
 
             nonWspFound = true;
-            resultLine.unshift(line[i]);
+            resultLine[writeIndex--] = line[i];
         }
 
         if (prevWsp && nonWspFound) {
-            resultLine.unshift(CHAR_SPACE);
+            resultLine[writeIndex--] = CHAR_SPACE;
         }
-
-        return Buffer.from(resultLine);
+        
+        return resultLine.slice(writeIndex + 1);
     }
 
     update(chunk, final) {


### PR DESCRIPTION
As explained on https://github.com/postalsys/mailauth/issues/64 , there is a DOS issue with the fixLineBuffer function.

This patch fixes the issue.

Since we couldn't catch the exact mail content creating this issue, I added a test script that creates a very long line email: https://github.com/postalsys/mailauth/issues/64#issuecomment-2295902343