### PR TITLE
chore: bumps undici to fix security vul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "nodemailer": "6.9.16",
                 "punycode.js": "2.3.1",
                 "tldts": "6.1.68",
-                "undici": "5.28.4",
+                "undici": "5.28.5",
                 "yargs": "17.7.2"
             },
             "bin": {
@@ -2980,10 +2980,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "5.28.4",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-            "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-            "license": "MIT",
+            "version": "5.28.5",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+            "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
             "dependencies": {
                 "@fastify/busboy": "^2.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "nodemailer": "6.9.16",
         "punycode.js": "2.3.1",
         "tldts": "6.1.68",
-        "undici": "5.28.4",
+        "undici": "5.28.5",
         "yargs": "17.7.2"
     },
     "engines": {


### PR DESCRIPTION
Fix for https://github.com/advisories/GHSA-c76h-2ccp-4975