### PR TITLE
fix: use minLength option for rsa keys

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -317,7 +317,7 @@ const getPublicKey = async (type, name, minBitLength, resolver) => {
 
         let modulusLength = publicKeyObj.asymmetricKeyDetails.modulusLength;
 
-        if (keyType === 'rsa' && modulusLength < 1024) {
+        if (keyType === 'rsa' && modulusLength < minBitLength) {
             let err = new Error('RSA key too short');
             err.code = 'ESHORTKEY';
             err.rr = rr;


### PR DESCRIPTION
The `minBitLength` seems to be ignored in the `getPublicKey` method