### PR TITLE
expose verifyASChain

### DIFF
--- a/lib/arc/index.js
+++ b/lib/arc/index.js
@@ -532,4 +532,4 @@ const sealMessage = async (input, seal) => {
     return headers.length ? Buffer.from(headers.join('\r\n') + '\r\n') : Buffer.from('');
 };
 
-module.exports = { getARChain, arc, createSeal, sealMessage };
+module.exports = { getARChain, verifyASChain, arc, createSeal, sealMessage };


### PR DESCRIPTION
Allows verifying the ARC chain without having to do the rest of the verifications.