### PR TITLE
Remove explicit @return type in raw mail authenticate function

### DIFF
--- a/lib/mailauth.js
+++ b/lib/mailauth.js
@@ -30,7 +30,7 @@ const { isIP } = require('net');
  * @param {Boolean} [opts.disableArc=false] If true then do not perform ARC validation and sealing
  * @param {Boolean} [opts.disableDmarc=false] If true then do not perform DMARC check
  * @param {Boolean} [opts.disableBimi=false] If true then do not perform BIMI check
- * @returns {Object} Authentication result
+ * @returns Authentication result
  */
 const authenticate = async (input, opts) => {
     opts = Object.assign({}, opts); // copy keys


### PR DESCRIPTION
This could ideally do with some concrete TypeScript types, but small steps first :).
I've noticed the `authenticate` function JSDoc explicitly sets the return type to `Object`, this means that most editors will:
- Display generic object-related functions, not useful at all.
- If you `await` the `authenticate` call, the editor will hint to you that the `await` has no effect (in TS it might error alltogether I believe), when this method does indeed returns a promise.

Removing the explicit type lets the editor infer some of the auth attributes returned in the object via intellisense, and corrects the incorrect non-async return type.