### PR TITLE
feat: add seal-only mode to the seal CLI command

### DIFF
--- a/bin/mailauth.js
+++ b/bin/mailauth.js
@@ -230,7 +230,28 @@ const argv = yargs(hideBin(process.argv))
                     alias: 'o',
                     type: 'boolean',
                     description: 'If set, outputs only the ARC seal headers without the message body.'
-                });
+                })
+                .option('auth-results', {
+                    type: 'string',
+                    description:
+                        'Authentication-Results value to embed in the ARC-Authentication-Results header (the part after "i=N;"). When set, the message is sealed using this value as is and no authentication checks are performed.'
+                })
+                .option('auth-results-file', {
+                    type: 'string',
+                    description: 'Path to a file containing the Authentication-Results value. Same as --auth-results, but read from a file.'
+                })
+                .option('cv', {
+                    type: 'string',
+                    choices: ['none', 'pass', 'fail'],
+                    description:
+                        'Chain validation status for the ARC-Seal header (cv= tag). Only used together with --auth-results or --auth-results-file. Defaults to "none".'
+                })
+                .option('instance', {
+                    type: 'number',
+                    description:
+                        'ARC instance number (i= tag). Only used together with --auth-results or --auth-results-file. Defaults to the next instance number based on the existing ARC chain, or 1.'
+                })
+                .conflicts('auth-results', 'auth-results-file');
             yargs.positional('email', {
                 describe: 'Path to the email message file in EML format. If not specified, the content is read from standard input.'
             });

--- a/cli.md
+++ b/cli.md
@@ -177,6 +177,20 @@ mailauth seal [options] [email]
 - `--header-fields "field1:field2"`, `-h "field1:field2"`: Colon-separated list of header fields to include in the seal (`h=` tag).
 - `--headers-only`, `-o`: Outputs only the ARC seal headers without the entire message.
 
+**Seal-Only Options:**
+
+By default, `seal` authenticates the message (SPF, DKIM, DMARC, ARC) and embeds the computed results in the `ARC-Authentication-Results` header. If the message was already authenticated elsewhere (for example at an edge MTA) and modified afterwards, you can instead provide the original `Authentication-Results` value yourself. When one of the following options is set, no authentication checks or DNS lookups are performed:
+
+- `--auth-results "authserv-id; spf=pass ..."`: `Authentication-Results` value to embed in the `ARC-Authentication-Results` header (the part after `i=N;`). Used as is.
+- `--auth-results-file /path/to/value.txt`: Same as `--auth-results`, but the value is read from a file. Useful for long or multi-line values. Cannot be combined with `--auth-results`.
+- `--cv status`: Chain validation status for the `ARC-Seal` header (`cv=` tag): `none`, `pass`, or `fail`. Defaults to `none`.
+- `--instance number`: ARC instance number (`i=` tag). Defaults to the next instance number based on the existing ARC chain of the message, or `1`.
+
+```bash
+mailauth seal message.eml -d example.com -s s1 -k private.key \
+  --cv pass --auth-results-file auth-results.txt --headers-only
+```
+
 **Authentication Options (from `report` command):**
 
 - `--client-ip x.x.x.x`, `-i x.x.x.x`: IP address of the remote client that sent the email.

--- a/lib/commands/seal.js
+++ b/lib/commands/seal.js
@@ -1,9 +1,24 @@
 'use strict';
 
 const { authenticate } = require('../mailauth');
+const { sealMessage } = require('../arc');
 const fs = require('node:fs');
 const { GathererStream } = require('../gatherer-stream');
 const { resolve } = require('node:dns').promises;
+
+const writeMessageBody = async gatherer =>
+    new Promise((resolve, reject) => {
+        let msgStream = gatherer.replay();
+
+        msgStream.pipe(process.stdout, { end: false });
+        msgStream.on('end', () => {
+            resolve();
+        });
+
+        msgStream.on('error', err => {
+            reject(err);
+        });
+    });
 
 const cmd = async argv => {
     let source = argv.email;
@@ -30,6 +45,57 @@ const cmd = async argv => {
     stream.on('error', err => gatherer.emit('error', err));
 
     let privateKey = await fs.promises.readFile(argv.privateKey, 'utf-8');
+
+    if (argv.authResults || argv.authResultsFile) {
+        // Seal-only mode: embed the caller-provided Authentication-Results value without authenticating the message
+        let authResults = argv.authResultsFile ? (await fs.promises.readFile(argv.authResultsFile, 'utf-8')).trim() : argv.authResults;
+
+        let sealOpts = {
+            signingDomain: argv.domain,
+            selector: argv.selector,
+            privateKey,
+            algorithm: argv.algo,
+            headerList: argv.headerFields,
+            signTime: argv.time ? new Date(argv.time * 1000) : new Date(),
+            authResults,
+            cv: argv.cv || 'none'
+        };
+
+        if (argv.instance) {
+            sealOpts.i = Number(argv.instance);
+        }
+
+        if (argv.verbose) {
+            console.error('Seal-only mode: sealing with provided authentication results, skipping authentication');
+            if (sealOpts.signingDomain) {
+                console.error(`Signing domain:             ${sealOpts.signingDomain}`);
+            }
+            if (sealOpts.selector) {
+                console.error(`Key selector:               ${sealOpts.selector}`);
+            }
+            if (sealOpts.algorithm) {
+                console.error(`Hashing algorithm:          ${sealOpts.algorithm}`);
+            }
+            if (sealOpts.signTime) {
+                console.error(`Signing time:               ${sealOpts.signTime.toISOString()}`);
+            }
+            console.error(`Chain validation status:    ${sealOpts.cv}`);
+            if (sealOpts.i) {
+                console.error(`ARC instance:               ${sealOpts.i}`);
+            }
+            console.error('--------');
+        }
+
+        let sealHeaders = await sealMessage(gatherer, sealOpts);
+
+        process.stdout.write(sealHeaders);
+        if (!argv.headersOnly) {
+            // print full message as well
+            await writeMessageBody(gatherer);
+        }
+        return;
+    }
+
     let signatureOpts = {
         signingDomain: argv.domain,
         selector: argv.selector,
@@ -113,18 +179,7 @@ const cmd = async argv => {
     process.stdout.write(result.headers);
     if (!argv.headersOnly) {
         // print full message as well
-        await new Promise((resolve, reject) => {
-            let msgStream = gatherer.replay();
-
-            msgStream.pipe(process.stdout, { end: false });
-            msgStream.on('end', () => {
-                resolve();
-            });
-
-            msgStream.on('error', err => {
-                reject(err);
-            });
-        });
+        await writeMessageBody(gatherer);
     }
 };
 

--- a/test/commands/seal-test.js
+++ b/test/commands/seal-test.js
@@ -1,0 +1,142 @@
+/* eslint no-unused-expressions:0 */
+'use strict';
+
+const { Buffer } = require('node:buffer');
+const chai = require('chai');
+const expect = chai.expect;
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const util = require('node:util');
+const execFile = util.promisify(require('node:child_process').execFile);
+
+const { authenticate } = require('../../lib/mailauth');
+
+const CLI_PATH = path.join(__dirname, '..', '..', 'bin', 'mailauth.js');
+const DENY_DNS_PATH = path.join(__dirname, '..', 'fixtures', 'deny-dns.js');
+const FIXTURES_PATH = path.join(__dirname, '..', 'fixtures');
+
+const AUTH_RESULTS = 'mx.shield.test; spf=pass smtp.mailfrom=example.com; dkim=pass header.i=@example.com; dmarc=pass header.from=example.com';
+
+// run the CLI in a child process where every DNS lookup is reported and rejected
+const runSeal = async args =>
+    execFile('node', ['-r', DENY_DNS_PATH, CLI_PATH, 'seal'].concat(args), {
+        env: Object.assign({}, process.env, { DENY_DNS: '1' })
+    });
+
+const keyArgs = ['-k', path.join(FIXTURES_PATH, 'private-rsa.pem'), '-d', 'tahvel.info', '-s', 'test.rsa'];
+
+// resolver that only knows the public key for the sealing selector
+const publicKeyPem = fs.readFileSync(path.join(FIXTURES_PATH, 'public-rsa.pem'), 'utf8');
+const publicKeyTxt = `v=DKIM1; k=rsa; p=${publicKeyPem.replace(/-+(BEGIN|END) PUBLIC KEY-+/g, '').replace(/\s+/g, '')}`;
+const resolver = async (name, rr) => {
+    if (rr === 'TXT' && name === 'test.rsa._domainkey.tahvel.info') {
+        return [[publicKeyTxt]];
+    }
+    let err = new Error('Error');
+    err.code = 'ENOTFOUND';
+    throw err;
+};
+
+describe('CLI seal command', function () {
+    this.timeout(15000);
+
+    let tmpDir;
+
+    before(async () => {
+        tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mailauth-seal-test-'));
+    });
+
+    after(async () => {
+        await fs.promises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    describe('seal-only mode (--auth-results)', () => {
+        it('should seal with the provided Authentication-Results without performing DNS lookups', async () => {
+            let { stdout, stderr } = await runSeal(keyArgs.concat(['--auth-results', AUTH_RESULTS, '-o', path.join(FIXTURES_PATH, 'message1.eml')]));
+
+            expect(stderr).to.not.include('DNS_LOOKUP_ATTEMPTED');
+
+            expect(stdout).to.match(/^ARC-Seal: i=1;/m);
+            expect(stdout).to.match(/^ARC-Message-Signature: i=1;/m);
+            expect(stdout).to.include('cv=none');
+            expect(stdout).to.include(`ARC-Authentication-Results: i=1; ${AUTH_RESULTS}`);
+        });
+
+        it('should read the Authentication-Results value from a file', async () => {
+            let authResultsFile = path.join(tmpDir, 'auth-results.txt');
+            let multiLineValue =
+                'mx.shield.test;\r\n spf=pass smtp.mailfrom=example.com;\r\n dkim=pass header.i=@example.com;\r\n dmarc=pass header.from=example.com';
+            await fs.promises.writeFile(authResultsFile, multiLineValue + '\r\n');
+
+            let { stdout, stderr } = await runSeal(
+                keyArgs.concat(['--auth-results-file', authResultsFile, '--cv', 'none', '-o', path.join(FIXTURES_PATH, 'message1.eml')])
+            );
+
+            expect(stderr).to.not.include('DNS_LOOKUP_ATTEMPTED');
+            expect(stdout).to.include(`ARC-Authentication-Results: i=1; ${multiLineValue}`);
+        });
+
+        it('should produce a seal that validates against the original message', async () => {
+            let { stdout } = await runSeal(keyArgs.concat(['--auth-results', AUTH_RESULTS, path.join(FIXTURES_PATH, 'message1.eml')]));
+
+            // without --headers-only the output is the sealed headers followed by the full message
+            let res = await authenticate(Buffer.from(stdout, 'binary'), {
+                ip: '127.0.0.1',
+                helo: 'example.com',
+                mta: 'example.com',
+                disableDmarc: true,
+                resolver
+            });
+
+            expect(res.arc.status.result).to.equal('pass');
+        });
+
+        it('should extend an existing ARC chain with the provided cv value', async () => {
+            let { stdout, stderr } = await runSeal(
+                keyArgs.concat(['--auth-results', AUTH_RESULTS, '--cv', 'pass', '-o', path.join(FIXTURES_PATH, 'arc-pass.eml')])
+            );
+
+            expect(stderr).to.not.include('DNS_LOOKUP_ATTEMPTED');
+
+            // arc-pass.eml already carries an ARC chain with instances 1 and 2
+            expect(stdout).to.match(/^ARC-Seal: i=3;/m);
+            expect(stdout).to.match(/^ARC-Message-Signature: i=3;/m);
+            expect(stdout).to.include('cv=pass');
+            expect(stdout).to.include(`ARC-Authentication-Results: i=3; ${AUTH_RESULTS}`);
+        });
+
+        it('should use an explicitly provided instance number', async () => {
+            let { stdout } = await runSeal(keyArgs.concat(['--auth-results', AUTH_RESULTS, '--instance', '5', '-o', path.join(FIXTURES_PATH, 'message1.eml')]));
+
+            expect(stdout).to.match(/^ARC-Seal: i=5;/m);
+            expect(stdout).to.include(`ARC-Authentication-Results: i=5; ${AUTH_RESULTS}`);
+        });
+
+        it('should reject using --auth-results and --auth-results-file together', async () => {
+            let failed = false;
+            try {
+                await runSeal(
+                    keyArgs.concat(['--auth-results', AUTH_RESULTS, '--auth-results-file', 'whatever.txt', '-o', path.join(FIXTURES_PATH, 'message1.eml')])
+                );
+            } catch (err) {
+                failed = true;
+            }
+            expect(failed).to.be.true;
+        });
+    });
+
+    describe('default mode (backward compatibility)', () => {
+        it('should authenticate and seal when no auth-results option is provided', async () => {
+            let dnsCacheFile = path.join(tmpDir, 'dns-cache.json');
+            await fs.promises.writeFile(dnsCacheFile, '{}');
+
+            let { stdout } = await runSeal(keyArgs.concat(['--dns-cache', dnsCacheFile, path.join(FIXTURES_PATH, 'message1.eml')]));
+
+            // the authenticate() path computes its own Authentication-Results header
+            expect(stdout).to.match(/^Authentication-Results:/m);
+            expect(stdout).to.match(/^ARC-Seal: i=1;/m);
+            expect(stdout).to.match(/^ARC-Authentication-Results: i=1;/m);
+        });
+    });
+});

--- a/test/fixtures/deny-dns.js
+++ b/test/fixtures/deny-dns.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// Preloaded with `node -r` in CLI tests to detect DNS lookups. Only active when
+// DENY_DNS is set, so this file is a no-op when picked up by the mocha test glob.
+if (process.env.DENY_DNS) {
+    const dns = require('node:dns');
+
+    const deny = name => {
+        process.stderr.write(`DNS_LOOKUP_ATTEMPTED ${name}\n`);
+        let err = new Error(`DNS lookup attempted for ${name}`);
+        err.code = 'ENOTFOUND';
+        throw err;
+    };
+
+    for (let key of Object.keys(dns.promises)) {
+        if (typeof dns.promises[key] === 'function' && /^(resolve|lookup|reverse)/.test(key)) {
+            dns.promises[key] = async name => deny(name);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The library already supports the documented "authenticate first, modify, then seal" pattern via `sealMessage(message, { ..., authResults, cv })`, but the `seal` CLI command always re-authenticates the message internally via `authenticate()`. That recomputed verdict is wrong when the message has been modified after the original authentication (e.g. an MTA that verified the pristine inbound message, then injected banners or rewrote MIME before relaying).

This PR exposes the existing library capability on the CLI: new opt-in options let `mailauth seal` embed a caller-provided `Authentication-Results` value and seal without performing any authentication checks or DNS lookups.

## New options on `mailauth seal`

- `--auth-results <value>` — `Authentication-Results` value to embed in `ARC-Authentication-Results` (the part after `i=N;`), used as-is
- `--auth-results-file <path>` — same, read from a file (convenient for long/folded values); conflicts with `--auth-results`
- `--cv <none|pass|fail>` — chain validation status for the `ARC-Seal` `cv=` tag, defaults to `none`
- `--instance <n>` — explicit ARC instance number; defaults to the next instance from any existing chain, or 1

When either auth-results option is set, the handler calls `sealMessage()` directly. The stdout contract is unchanged: the three `ARC-*` headers, then the message body unless `--headers-only` is set. All new flags are long-only to avoid clashing with the existing short aliases.

## Backward compatibility

Without the new options the command runs the existing `authenticate()`-and-seal path unchanged — the new mode is strictly opt-in. No library code is touched; only `lib/commands/seal.js`, the yargs builder in `bin/mailauth.js`, and `cli.md`.

## Tests

New CLI tests (`test/commands/seal-test.js`) spawn the real binary with a preload script (`test/fixtures/deny-dns.js`) that intercepts every `dns.promises` resolver and reports any lookup, proving the seal-only path is fully offline:

- `ARC-Authentication-Results` echoes the supplied value verbatim (inline and from file) with zero DNS lookups
- the produced seal round-trips: `authenticate()` with a mock resolver validates the chain as `arc=pass`
- an existing ARC chain is extended at the correct next instance with `cv=pass`
- explicit `--instance` is honored
- `--auth-results` and `--auth-results-file` together is rejected
- default mode still authenticates and seals as before (run offline via `--dns-cache`)

Full suite passes (682 tests), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)