### PR TITLE
fix: update dependencies to latest minor/patch versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
             "version": "4.13.3",
             "license": "MIT",
             "dependencies": {
-                "@postalsys/vmc": "1.1.4",
-                "fast-xml-parser": "5.7.3",
+                "@postalsys/vmc": "1.1.5",
+                "fast-xml-parser": "5.10.1",
                 "ipaddr.js": "2.4.0",
-                "joi": "18.2.1",
-                "libmime": "5.3.8",
+                "joi": "18.2.3",
+                "libmime": "5.4.1",
                 "nodemailer": "8.0.7",
                 "punycode.js": "2.3.1",
-                "tldts": "7.0.30",
+                "tldts": "7.4.9",
                 "undici": "7.25.0",
                 "yargs": "17.7.2"
             },
@@ -293,9 +293,9 @@
             "license": "MIT"
         },
         "node_modules/@nodable/entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+            "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
             "funding": [
                 {
                     "type": "github",
@@ -305,37 +305,46 @@
             "license": "MIT"
         },
         "node_modules/@peculiar/asn1-schema": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-            "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+            "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
             "license": "MIT",
             "dependencies": {
-                "asn1js": "^3.0.6",
-                "pvtsutils": "^1.3.6",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-x509": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
-            "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+            "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.6.0",
-                "asn1js": "^3.0.6",
-                "pvtsutils": "^1.3.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-x509-logotype": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-logotype/-/asn1-x509-logotype-2.6.1.tgz",
-            "integrity": "sha512-VJV5Azg0M8TMAZfE5pB9eQOLXxc/9sGS08kVJhMQYv7dB2YBwiasp/GRZIuit+0t4Sr9FnoEpwwXAHXOlLdMnA==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-logotype/-/asn1-x509-logotype-2.8.0.tgz",
+            "integrity": "sha512-79px79a3YB8OnzVh+hbUlJKNaWymsf+im26AsgHnOhZ1859qVR4P0C4JBq/52dF8LXzNfvioqIOew1Xg7l2nDA==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.6.0",
-                "@peculiar/asn1-x509": "^2.6.1",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+            "license": "MIT",
+            "dependencies": {
                 "tslib": "^2.8.1"
             }
         },
@@ -351,14 +360,14 @@
             }
         },
         "node_modules/@postalsys/vmc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@postalsys/vmc/-/vmc-1.1.4.tgz",
-            "integrity": "sha512-nz7xaISzluVKjmiDVFIPP8A0IVo6exjRuJ5QXeBnl5UiaRnIBQlw56PHYDNJ6xnsHSfb+iaLb6V2F/CEhJLdPA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@postalsys/vmc/-/vmc-1.1.5.tgz",
+            "integrity": "sha512-WwleGWC51o/VWQFTId6xMiO9aqkIVCM7ODy6UWfzFoQ6UzXewsNrm3ANa4HbBcyYaTK6YPvp4Gt0U+1cXLTbzw==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "2.6.0",
-                "@peculiar/asn1-x509": "2.6.1",
-                "@peculiar/asn1-x509-logotype": "2.6.1"
+                "@peculiar/asn1-schema": "2.8.0",
+                "@peculiar/asn1-x509": "2.8.0",
+                "@peculiar/asn1-x509-logotype": "2.8.0"
             }
         },
         "node_modules/@sec-ant/readable-stream": {
@@ -482,6 +491,18 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/anynum": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/argparse": {
             "version": "2.0.1",
@@ -1154,9 +1175,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-            "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+            "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
             "funding": [
                 {
                     "type": "github",
@@ -1165,13 +1186,30 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@nodable/entities": "^2.1.0",
-                "fast-xml-builder": "^1.1.7",
-                "path-expression-matcher": "^1.5.0",
-                "strnum": "^2.2.3"
+                "@nodable/entities": "^3.0.0",
+                "fast-xml-builder": "^1.2.0",
+                "is-unsafe": "^2.0.0",
+                "path-expression-matcher": "^1.6.2",
+                "strnum": "^2.4.1",
+                "xml-naming": "^0.3.0"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/fast-xml-parser/node_modules/xml-naming": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+            "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/file-entry-cache": {
@@ -1471,9 +1509,9 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1603,6 +1641,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-unsafe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+            "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1627,9 +1677,9 @@
             }
         },
         "node_modules/joi": {
-            "version": "18.2.1",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
-            "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+            "version": "18.2.3",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+            "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@hapi/address": "^5.1.1",
@@ -1709,13 +1759,13 @@
             "license": "MIT"
         },
         "node_modules/libmime": {
-            "version": "5.3.8",
-            "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
-            "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.4.1.tgz",
+            "integrity": "sha512-0wHGhsofo9IdQPenr3BBHXuxcwMq4atFUTsZ9Ogc1OvI5h4rUdDIrBQEN9JHjCXfDMrE59LUMJWsTD82wTYk8A==",
             "license": "MIT",
             "dependencies": {
                 "encoding-japanese": "2.2.0",
-                "iconv-lite": "0.7.2",
+                "iconv-lite": "0.7.3",
                 "libbase64": "1.3.0",
                 "libqp": "2.1.1"
             }
@@ -2101,9 +2151,9 @@
             }
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+            "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2559,16 +2609,19 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-            "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "anynum": "^1.0.1"
+            }
         },
         "node_modules/supports-color": {
             "version": "8.1.1",
@@ -2684,21 +2737,21 @@
             "license": "MIT"
         },
         "node_modules/tldts": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+            "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.30"
+                "tldts-core": "^7.4.9"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+            "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
             "license": "MIT"
         },
         "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
         "resedit": "3.0.2"
     },
     "dependencies": {
-        "@postalsys/vmc": "1.1.4",
-        "fast-xml-parser": "5.7.3",
+        "@postalsys/vmc": "1.1.5",
+        "fast-xml-parser": "5.10.1",
         "ipaddr.js": "2.4.0",
-        "joi": "18.2.1",
-        "libmime": "5.3.8",
+        "joi": "18.2.3",
+        "libmime": "5.4.1",
         "nodemailer": "8.0.7",
         "punycode.js": "2.3.1",
-        "tldts": "7.0.30",
+        "tldts": "7.4.9",
         "undici": "7.25.0",
         "yargs": "17.7.2"
     },


### PR DESCRIPTION
Updates all dependencies with available minor/patch releases (majors deliberately excluded):

| Package | From | To |
|---|---|---|
| @postalsys/vmc | 1.1.4 | 1.1.5 |
| fast-xml-parser | 5.7.3 | 5.10.1 |
| joi | 18.2.1 | 18.2.3 |
| libmime | 5.3.8 | 5.4.1 |
| tldts | 7.0.30 | 7.4.9 |

Major updates NOT included: nodemailer 8→9, undici 7→8, yargs 17→18.

Full test suite passes: 675 passing (lint + mocha).