### PR TITLE
Replace tldts with tldkit

### DIFF
--- a/lib/dmarc/get-dmarc-record.js
+++ b/lib/dmarc/get-dmarc-record.js
@@ -2,7 +2,7 @@
 
 const dns = require('node:dns').promises;
 const tldkit = require('tldkit');
-const { PSL_OPTS } = require('../tools');
+const { TLDTS_OPTS } = require('../tools');
 
 // Tags whose values are ABNF literals in RFC 7489 6.4 / RFC 9989 4.7 and are therefore
 // case insensitive (RFC 5234 2.3). Values of other tags keep their case: "v" is defined
@@ -31,7 +31,7 @@ const getDmarcRecord = async (domain, resolver) => {
     let isOrgRecord = false;
 
     if (!records.length) {
-        let orgDomain = tldkit.getDomain(domain, PSL_OPTS);
+        let orgDomain = tldkit.getDomain(domain, TLDTS_OPTS);
         // No registrable domain, so there is nothing to inherit a policy from.
         // Without this the fallback would query `_dmarc.null`.
         if (orgDomain && orgDomain !== domain) {

--- a/lib/dmarc/get-dmarc-record.js
+++ b/lib/dmarc/get-dmarc-record.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const dns = require('node:dns').promises;
-const tldts = require('tldts');
-const { TLDTS_OPTS } = require('../tools');
+const tldkit = require('tldkit');
+const { PSL_OPTS } = require('../tools');
 
 // Tags whose values are ABNF literals in RFC 7489 6.4 / RFC 9989 4.7 and are therefore
 // case insensitive (RFC 5234 2.3). Values of other tags keep their case: "v" is defined
@@ -31,7 +31,7 @@ const getDmarcRecord = async (domain, resolver) => {
     let isOrgRecord = false;
 
     if (!records.length) {
-        let orgDomain = tldts.getDomain(domain, TLDTS_OPTS);
+        let orgDomain = tldkit.getDomain(domain, PSL_OPTS);
         if (orgDomain !== domain) {
             // try org domain as well
             records = await resolveTxt(orgDomain, resolver);

--- a/lib/dmarc/get-dmarc-record.js
+++ b/lib/dmarc/get-dmarc-record.js
@@ -32,7 +32,9 @@ const getDmarcRecord = async (domain, resolver) => {
 
     if (!records.length) {
         let orgDomain = tldkit.getDomain(domain, PSL_OPTS);
-        if (orgDomain !== domain) {
+        // No registrable domain, so there is nothing to inherit a policy from.
+        // Without this the fallback would query `_dmarc.null`.
+        if (orgDomain && orgDomain !== domain) {
             // try org domain as well
             records = await resolveTxt(orgDomain, resolver);
             isOrgRecord = true;

--- a/lib/dmarc/verify.js
+++ b/lib/dmarc/verify.js
@@ -3,7 +3,7 @@
 const dns = require('node:dns').promises;
 const punycode = require('punycode.js');
 const tldkit = require('tldkit');
-const { formatAuthHeaderRow, getAlignment, PSL_OPTS } = require('../tools');
+const { formatAuthHeaderRow, getAlignment, TLDTS_OPTS } = require('../tools');
 const getDmarcRecord = require('./get-dmarc-record');
 
 const verifyDmarc = async opts => {
@@ -41,7 +41,7 @@ const verifyDmarc = async opts => {
         return response;
     };
 
-    let orgDomain = tldkit.getDomain(domain, PSL_OPTS);
+    let orgDomain = tldkit.getDomain(domain, TLDTS_OPTS);
 
     let status = {
         result: 'neutral',

--- a/lib/dmarc/verify.js
+++ b/lib/dmarc/verify.js
@@ -2,8 +2,8 @@
 
 const dns = require('node:dns').promises;
 const punycode = require('punycode.js');
-const tldts = require('tldts');
-const { formatAuthHeaderRow, getAlignment, TLDTS_OPTS } = require('../tools');
+const tldkit = require('tldkit');
+const { formatAuthHeaderRow, getAlignment, PSL_OPTS } = require('../tools');
 const getDmarcRecord = require('./get-dmarc-record');
 
 const verifyDmarc = async opts => {
@@ -41,7 +41,7 @@ const verifyDmarc = async opts => {
         return response;
     };
 
-    let orgDomain = tldts.getDomain(domain, TLDTS_OPTS);
+    let orgDomain = tldkit.getDomain(domain, PSL_OPTS);
 
     let status = {
         result: 'neutral',

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -10,7 +10,7 @@ const crypto = require('node:crypto');
 const https = require('node:https');
 const packageData = require('../package');
 const parseDkimHeaders = require('./parse-dkim-headers');
-const tldts = require('tldts');
+const tldkit = require('tldkit');
 const Joi = require('joi');
 const base64Schema = Joi.string().base64({ paddingRequired: false });
 
@@ -29,7 +29,7 @@ const keyOrderingDKIM = ['v', 'a', 'c', 'd', 'h', 'i', 'l', 'q', 's', 't', 'x', 
 const keyOrderingARC = ['i', 'a', 'c', 'd', 'h', 'l', 'q', 's', 't', 'x', 'z', 'bh', 'b'];
 const keyOrderingAS = ['i', 'a', 't', 'cv', 'd', 's', 'b'];
 
-const TLDTS_OPTS = {
+const PSL_OPTS = {
     allowIcannDomains: true,
     allowPrivateDomains: true
 };
@@ -504,9 +504,9 @@ const getAlignment = (fromDomain, domainList, strict) => {
     }
 
     // relaxed alignment: the domains must share an Organizational Domain (RFC 9989 §3.2.10.1)
-    let fromOrg = formatDomain(tldts.getDomain(fromDomain, TLDTS_OPTS) || fromDomain);
+    let fromOrg = formatDomain(tldkit.getDomain(fromDomain, PSL_OPTS) || fromDomain);
     for (let entry of domainList) {
-        let entryOrg = formatDomain(tldts.getDomain(entry.domain, TLDTS_OPTS) || entry.domain);
+        let entryOrg = formatDomain(tldkit.getDomain(entry.domain, PSL_OPTS) || entry.domain);
         if (entryOrg === fromOrg) {
             return entry;
         }
@@ -773,7 +773,7 @@ module.exports = {
 
     getCurTime,
 
-    TLDTS_OPTS,
+    PSL_OPTS,
 
     validateTagValueRecord,
     parseTagValueRecord,

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -774,7 +774,7 @@ module.exports = {
     getCurTime,
 
     PSL_OPTS,
-
+    TLDTS_OPTS: PSL_OPTS,
     validateTagValueRecord,
     parseTagValueRecord,
     convertToASCII

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -29,7 +29,7 @@ const keyOrderingDKIM = ['v', 'a', 'c', 'd', 'h', 'i', 'l', 'q', 's', 't', 'x', 
 const keyOrderingARC = ['i', 'a', 'c', 'd', 'h', 'l', 'q', 's', 't', 'x', 'z', 'bh', 'b'];
 const keyOrderingAS = ['i', 'a', 't', 'cv', 'd', 's', 'b'];
 
-const PSL_OPTS = {
+const TLDTS_OPTS = {
     allowIcannDomains: true,
     allowPrivateDomains: true
 };
@@ -504,9 +504,9 @@ const getAlignment = (fromDomain, domainList, strict) => {
     }
 
     // relaxed alignment: the domains must share an Organizational Domain (RFC 9989 §3.2.10.1)
-    let fromOrg = formatDomain(tldkit.getDomain(fromDomain, PSL_OPTS) || fromDomain);
+    let fromOrg = formatDomain(tldkit.getDomain(fromDomain, TLDTS_OPTS) || fromDomain);
     for (let entry of domainList) {
-        let entryOrg = formatDomain(tldkit.getDomain(entry.domain, PSL_OPTS) || entry.domain);
+        let entryOrg = formatDomain(tldkit.getDomain(entry.domain, TLDTS_OPTS) || entry.domain);
         if (entryOrg === fromOrg) {
             return entry;
         }
@@ -773,7 +773,7 @@ module.exports = {
 
     getCurTime,
 
-    PSL_OPTS,
+    TLDTS_OPTS,
 
     validateTagValueRecord,
     parseTagValueRecord,

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -774,7 +774,7 @@ module.exports = {
     getCurTime,
 
     PSL_OPTS,
-    TLDTS_OPTS: PSL_OPTS,
+
     validateTagValueRecord,
     parseTagValueRecord,
     convertToASCII

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "libmime": "5.3.8",
                 "nodemailer": "8.0.7",
                 "punycode.js": "2.3.1",
-                "tldts": "7.0.30",
+                "tldkit": "1.0.2",
                 "undici": "7.25.0",
                 "yargs": "17.7.2"
             },
@@ -2683,23 +2683,14 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/tldts": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+        "node_modules/tldkit": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/tldkit/-/tldkit-1.0.2.tgz",
+            "integrity": "sha512-c9reSPdQLmnSFK70NDsEoywHGTxrQ+LobvIHoErf3BoaCDRMvl61+2hIqOXIoUFwwXTFhxlhRvtu48ilz1jqHA==",
             "license": "MIT",
-            "dependencies": {
-                "tldts-core": "^7.0.30"
-            },
-            "bin": {
-                "tldts": "bin/cli.js"
+            "engines": {
+                "node": ">=16"
             }
-        },
-        "node_modules/tldts-core": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
-            "license": "MIT"
         },
         "node_modules/tslib": {
             "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "libmime": "5.3.8",
         "nodemailer": "8.0.7",
         "punycode.js": "2.3.1",
-        "tldts": "7.0.30",
+        "tldkit": "1.0.2",
         "undici": "7.25.0",
         "yargs": "17.7.2"
     },


### PR DESCRIPTION
Replaces `tldts` with `tldkit` for organizational domain lookups. Three files call `getDomain(host, opts)` with the same options as before: `lib/tools.js`, `lib/dmarc/verify.js` and `lib/dmarc/get-dmarc-record.js`. I also renamed the internal `TLDTS_OPTS` constant to `PSL_OPTS`; happy to drop that. Pinned exactly, like the rest of `dependencies`. `npm test` passes.

The reason is install size. Whole tree, tldts plus tldts-core is 3,186.9 KB against 140.9 KB for tldkit. About 1,809 KB of that is sourcemaps across 33 files, and the suffix trie ships several times over: source, types, both module formats, and inlined into three prebuilt bundles. Heap with the list resident is 1,140 KB against 645 KB. Warm lookup throughput is at parity. tldkit unpacks its dataset on the first lookup rather than at module load, so the first call costs 0.77 ms against 0.33 ms.

One behaviour difference to weigh before taking this, since it feeds DMARC alignment. The two disagree on 7 nested wildcard families, where a rule `*.X` has a deeper sibling `*.L.X`. tldkit follows the publicsuffix.org algorithm and returns no registrable domain for those hosts; tldts returns one. For `mtls.run.app`, tldts gives `run.app` and tldkit gives null. It only shows up with `allowPrivateDomains: true`, which is what mailauth sets, so it is reachable.

tldkit has no runtime dependencies, ships CJS and ESM with types, Node 16+. It scores 76/78 on the publicsuffix.org conformance suite, the same score and the same two failures as tldts, and was checked against tldts over 105,146 cases covering every rule under both `allowPrivateDomains` settings. The dataset is committed so install touches no network, and a weekly job regenerates it and opens a PR when the list moves. Releases go out with npm trusted publishing, so they carry provenance.

I wrote tldkit: https://github.com/Damin3927/tldkit
