### PR TITLE
fix(spf): expand %{d} macro to the domain currently being evaluated

### DIFF
--- a/lib/spf/macro.js
+++ b/lib/spf/macro.js
@@ -12,11 +12,12 @@ const os = require('node:os');
  * @param {String} values.ip Sender IP address
  * @param {String} values.helo Client's HELO/EHLO domain
  * @param {String} [values.mta] Hostname of the MTA or MX server that processes the message
+ * @param {String} [values.domain] Domain currently being evaluated by check_host(), changes on include/redirect recursion (RFC 7208 sections 5.2, 6.1)
  */
 const macro = (input, values) => {
     input = (input || '').toString();
 
-    let { sender, ip, helo, mta } = values || {};
+    let { sender, ip, helo, mta, domain } = values || {};
 
     sender = (sender || '').toString();
     ip = (ip || '').toString();
@@ -64,9 +65,13 @@ const macro = (input, values) => {
                 break;
 
             case 'o':
-            case 'd':
             case 'p': // validated domain name is unsupported, instead we use the unvalidated sender domain
                 curval = senderDomain;
+                break;
+
+            case 'd':
+                // current <domain> of check_host(), not the sender domain (these only match at the top level)
+                curval = domain || senderDomain;
                 break;
 
             case 'i':

--- a/lib/spf/spf-verify.js
+++ b/lib/spf/spf-verify.js
@@ -72,6 +72,9 @@ const spfVerify = async (domain, opts) => {
 
     let addr = ipaddr.parse(opts.ip);
 
+    // %{d} must expand to the domain currently being evaluated, which changes on include/redirect recursion
+    let macroValues = { sender: opts.sender, ip: opts.ip, helo: opts.helo, mta: opts.mta, domain };
+
     let resolver = opts.resolver || dns.resolve;
 
     let responses;
@@ -135,7 +138,7 @@ const spfVerify = async (domain, opts) => {
                 let modifier = part.substr(0, splitPos).toLowerCase();
                 let value = part.substr(splitPos + 1);
 
-                value = macro(value, opts)
+                value = macro(value, macroValues)
                     // remove trailing dot
                     .replace(/\.$/, '');
 
@@ -254,7 +257,7 @@ const spfVerify = async (domain, opts) => {
                 case 'include':
                     {
                         try {
-                            let redirect = macro(val, opts)
+                            let redirect = macro(val, macroValues)
                                 // remove trailing dot
                                 .replace(/\.$/, '');
                             let sub = await spfVerify(redirect, opts);
@@ -328,7 +331,7 @@ const spfVerify = async (domain, opts) => {
                         let { domain: a, cidr4, cidr6 } = parseCidrValue(val, domain, type);
                         let cidr = net.isIPv6(opts.ip) ? cidr6 : cidr4;
 
-                        a = macro(a, opts);
+                        a = macro(a, macroValues);
 
                         try {
                             a = punycode.toASCII(a);
@@ -354,7 +357,7 @@ const spfVerify = async (domain, opts) => {
                         let { domain: mxDomain, cidr4, cidr6 } = parseCidrValue(val, domain, type);
                         let cidr = net.isIPv6(opts.ip) ? cidr6 : cidr4;
 
-                        mxDomain = macro(mxDomain, opts);
+                        mxDomain = macro(mxDomain, macroValues);
 
                         try {
                             mxDomain = punycode.toASCII(mxDomain);
@@ -397,7 +400,7 @@ const spfVerify = async (domain, opts) => {
 
                 case 'exists':
                     {
-                        let existDomain = macro(val, opts);
+                        let existDomain = macro(val, macroValues);
                         try {
                             existDomain = punycode.toASCII(existDomain);
                         } catch (err) {
@@ -420,12 +423,8 @@ const spfVerify = async (domain, opts) => {
                             throw err;
                         }
 
-                        let ptrDomain;
-                        if (val) {
-                            ptrDomain = macro(val, opts);
-                        } else {
-                            ptrDomain = macro('%{d}', opts);
-                        }
+                        // bare "ptr" defaults to %{d}, the currently evaluated domain
+                        let ptrDomain = val ? macro(val, macroValues) : domain;
                         ptrDomain = formatDomain(ptrDomain);
 
                         // Step 1. Resolve PTR hostnames

--- a/test/spf/macro-test.js
+++ b/test/spf/macro-test.js
@@ -38,4 +38,20 @@ describe('SPF Macro Tests', () => {
             '1.0.b.c.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6._spf.example.com'
         );
     });
+
+    it('Should expand %{d} using the currently evaluated domain, not the sender domain', async () => {
+        let sender = 'strong-bad@email.example.com';
+        let domain = 'included.example.net';
+        let ipv4 = '192.0.2.3';
+
+        // %{d} follows <domain>, %{o} and %{s} stay on the sender (RFC 7208 sections 7.2, 7.3)
+        expect(macro('%{d}', { sender, domain })).to.equal('included.example.net');
+        expect(macro('%{d2}', { sender, domain })).to.equal('example.net');
+        expect(macro('%{o}', { sender, domain })).to.equal('email.example.com');
+        expect(macro('%{s}', { sender, domain })).to.equal('strong-bad@email.example.com');
+        expect(macro('%{ir}.%{v}.%{d}.spf.example.org', { sender, domain, ip: ipv4 })).to.equal('3.2.0.192.in-addr.included.example.net.spf.example.org');
+
+        // without an explicit domain, %{d} falls back to the sender domain (top-level evaluation)
+        expect(macro('%{d}', { sender })).to.equal('email.example.com');
+    });
 });

--- a/test/spf/spf-verify-test.js
+++ b/test/spf/spf-verify-test.js
@@ -505,4 +505,78 @@ describe('SPF Verifier Tests', () => {
             expect(err.spfResult.error).to.equal('temperror');
         }
     });
+
+    it('Should expand %{d} to the included domain in nested includes', async () => {
+        // Regression test for https://github.com/postalsys/mailauth/issues/125
+        // sender.example -> include:mid.example -> include:policy.example
+        // policy.example uses include:%{ir}.%{v}.%{d}.spf.provider.example where
+        // %{d} must expand to policy.example (the domain being evaluated), not sender.example
+        const queried = [];
+        const stubResolver = (domain, type) => {
+            queried.push(`${type} ${domain}`);
+            if (type === 'TXT') {
+                switch (domain) {
+                    case 'sender.example':
+                        return [['v=spf1 include:mid.example ~all']];
+                    case 'mid.example':
+                        return [['v=spf1 include:policy.example ~all']];
+                    case 'policy.example':
+                        return [['v=spf1 include:%{ir}.%{v}.%{d}.spf.provider.example ~all']];
+                    case '3.2.0.192.in-addr.policy.example.spf.provider.example':
+                        return [['v=spf1 ip4:192.0.2.3 -all']];
+                }
+            }
+            let err = new Error(`ENOTFOUND ${domain}`);
+            err.code = 'ENOTFOUND';
+            throw err;
+        };
+
+        let result = await spfVerify('sender.example', { ip: '192.0.2.3', sender: 'user@sender.example', resolver: stubResolver });
+        expect(result.qualifier).to.equal('+');
+        expect(queried).to.include('TXT 3.2.0.192.in-addr.policy.example.spf.provider.example');
+        expect(queried.filter(q => q.includes('sender.example.spf.provider.example'))).to.be.empty;
+    });
+
+    it('Should keep %{o} on the sender domain in nested includes', async () => {
+        const stubResolver = (domain, type) => {
+            if (type === 'TXT') {
+                switch (domain) {
+                    case 'sender.example':
+                        return [['v=spf1 include:policy.example -all']];
+                    case 'policy.example':
+                        return [['v=spf1 include:%{o}.spf.provider.example -all']];
+                    case 'sender.example.spf.provider.example':
+                        return [['v=spf1 ip4:192.0.2.3 -all']];
+                }
+            }
+            let err = new Error(`ENOTFOUND ${domain}`);
+            err.code = 'ENOTFOUND';
+            throw err;
+        };
+
+        let result = await spfVerify('sender.example', { ip: '192.0.2.3', sender: 'user@sender.example', resolver: stubResolver });
+        expect(result.qualifier).to.equal('+');
+    });
+
+    it('Should expand %{d} to the redirect target domain after a redirect', async () => {
+        const stubResolver = (domain, type) => {
+            if (type === 'TXT') {
+                switch (domain) {
+                    case 'sender.example':
+                        return [['v=spf1 redirect=redirected.example']];
+                    case 'redirected.example':
+                        return [['v=spf1 exists:%{ir}.%{d}.spf.provider.example -all']];
+                }
+            }
+            if (type === 'A' && domain === '3.2.0.192.redirected.example.spf.provider.example') {
+                return ['127.0.0.2'];
+            }
+            let err = new Error(`ENOTFOUND ${domain}`);
+            err.code = 'ENOTFOUND';
+            throw err;
+        };
+
+        let result = await spfVerify('sender.example', { ip: '192.0.2.3', sender: 'user@sender.example', resolver: stubResolver });
+        expect(result.qualifier).to.equal('+');
+    });
 });


### PR DESCRIPTION
RFC 7208 defines `d` as the current `<domain>` of check_host(), which changes on every `include:`/`redirect=` recursion, while `o` stays on the sender domain (sections 5.2, 6.1, 7.2, 7.3). mailauth expanded `%{d}` as an alias of `%{o}`, so macros inside nested SPF records were built from the wrong domain, producing bogus DNS lookups and spurious permerrors, as reported in #125.

Changes:

- `lib/spf/macro.js`: `d` now expands from a new optional `values.domain` (falling back to the sender domain, which is the correct top-level value), `o` and `p` keep using the sender domain
- `lib/spf/spf-verify.js`: each `spfVerify()` recursion level passes its own `domain` to every macro expansion site; the bare `ptr` mechanism now uses the current domain directly
- Regression tests: nested-include `%{d}` expansion mirroring the reported chain (asserting the wrong hostname is never queried), `%{d}` after `redirect=`, `%{o}` staying on the sender in nested includes, and macro unit tests. All three `%{d}` tests fail on master and pass with this fix; the full suite (756 tests, including the RFC 7208 test suite) passes.